### PR TITLE
Decouple config from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Notes:
 2. Once you run the app it will create a `token.pickle` file within the same directory, and that file will be used for subsequent authorizations/verifications to the Google services.
 3. Configure the `config.py` file with your Syanpse credentials (_username/password_) found in `ingresspipe/config/config.py`.
 
-Create a conda environment in the cloned directory:
+Create a conda environment in the cloned directory from the `environment.yml` which has all the required package dependencies:
 
-    conda create --name data_curator_env
+    conda env create -f environment.yml
 
-Here we are calling our conda environment `data_curator_env`. You can change it anything you like, but please note that you will need to make changes accordingly in the `app.R` file.
+Here our conda environment name `data_curator_env` set from the `environment.yml` file. You can change it anything you like, but please note that you will need to make changes accordingly in the `app.R` file.
 
 Activate the `data_curator_env` environment:
 
@@ -29,11 +29,19 @@ Install the backend (`ingresspipe` package) within the conda virtual environment
 
 Note: _For more instructions see, [Data Ingress Pipeline Docs](https://github.com/Sage-Bionetworks/HTAN-data-pipeline/tree/organized-into-packages#readme)_.
 
-To verify that the backend is installed do (either of) the following:
+To verify that the backend is installed do either of the following:
+
+A.
 
     pip list
 
-See if you can find the `ingresspipe` package in the list of packages installed using `pip`.
+or 
+
+    conda list
+   
+See if you can find the `ingresspipe` package in the list of packages installed.
+
+B.
 
 Run any example(s) from within the `ingresspipe` package as follows:
 

--- a/app.R
+++ b/app.R
@@ -217,7 +217,7 @@ server <- function(input, output, session) {
     showNotification(id = "processing", "Please wait while we log you in...", duration = NULL, type = "warning")
 
     ### logs in 
-    # syn_login(sessionToken = input$cookie, rememberMe = FALSE)
+    syn_login(sessionToken = input$cookie, rememberMe = FALSE)
 
     ### welcome message
     output$title <- renderUI({
@@ -225,10 +225,10 @@ server <- function(input, output, session) {
     })
 
     ### updating global vars with values for projects
-    # synStore_obj <<- syn_store("syn20446927", token = input$cookie)
+    synStore_obj <<- syn_store("syn20446927", token = input$cookie)
 
     # get_projects_list(synStore_obj)
-    projects_list <<- syn_store$getStorageProjects()
+    projects_list <<- syn_store$getStorageProjects(synStore_obj)
 
     for (i in seq_along(projects_list)) {
       projects_namedList[projects_list[[i]][[2]]] <<- projects_list[[i]][[1]]
@@ -290,7 +290,7 @@ list_tabs <- c("instructions", "data", "template", "upload")
         project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
 
         ### gets folders per project
-        folder_list <- syn_store$getStorageDatasetsInProject(project_synID)
+        folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
         folders_namedList <- c()
         for (i in seq_along(folder_list)) {
           folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
@@ -325,7 +325,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
 
     project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
 
-    folder_list <- syn_store$getStorageDatasetsInProject(project_synID)
+    folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
     folders_namedList <- c()
     for (i in seq_along(folder_list)) {
       folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
@@ -334,12 +334,12 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
     # showNotification( folder_synID, duration = NULL, type = "warning")
 
     ### checks if a manifest already exists
-    existing_manifestID <- syn_store$updateDatasetManifestFiles(folder_synID)
+    existing_manifestID <- syn_store$updateDatasetManifestFiles(synStore_obj, folder_synID)
     # showNotification( paste0("existing manifest: ", existing_manifestID) , duration = NULL, type = "warning")
 
     ### if there isn't an existing manifest make a new one 
     if (existing_manifestID == '') {
-      file_list <- syn_store$getFilesInStorageDataset(folder_synID)
+      file_list <- syn_store$getFilesInStorageDataset(synStore_obj, folder_synID)
       file_namedList <- c()
       for (i in seq_along(file_list)) {
         file_namedList[file_list[[i]][[2]]] <- file_list[[i]][[1]]
@@ -519,7 +519,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
         selected_project <- input$var
 
         project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
-        folder_list <- syn_store$getStorageDatasetsInProject(project_synID)
+        folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
         folders_namedList <- c()
         for (i in seq_along(folder_list)) {
           folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
@@ -527,7 +527,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
 
         folder_synID <- folders_namedList[[selected_folder]]
 
-        file_list <- syn_store$getFilesInStorageDataset(folder_synID)
+        file_list <- syn_store$getFilesInStorageDataset(synStore_obj, folder_synID)
         file_namedList <- c()
         for (i in seq_along(file_list)) {
           file_namedList[file_list[[i]][[2]]] <- file_list[[i]][[1]]
@@ -544,7 +544,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
 
       project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
 
-      folder_list <- syn_store$getStorageDatasetsInProject(project_synID)
+      folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
       folders_namedList <- c()
       for (i in seq_along(folder_list)) {
         folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
@@ -552,7 +552,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       folder_synID <- folders_namedList[[selected_folder]]
 
       ### associates metadata with data and returns manifest id
-      manifest_id <- syn_store$associateMetadataWithFiles("./files/synapse_storage_manifest.csv", folder_synID)
+      manifest_id <- syn_store$associateMetadataWithFiles(synStore_obj, "./files/synapse_storage_manifest.csv", folder_synID)
       print(manifest_id)
       manifest_path <- paste0("synapse.org/#!Synapse:", manifest_id)
       ### if no error 
@@ -596,7 +596,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
       # folder_synID <- get_folder_synID(synStore_obj, project_synID, selected_folder)
 
-      folder_list <- syn_store$getStorageDatasetsInProject(project_synID)
+      folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
       folders_namedList <- c()
       for (i in seq_along(folder_list)) {
         folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
@@ -604,7 +604,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       folder_synID <- folders_namedList[[selected_folder]]
 
       ### associates metadata with data and returns manifest id
-      manifest_id <- syn_store$associateMetadataWithFiles("./files/synapse_storage_manifest.csv", folder_synID)
+      manifest_id <- syn_store$associateMetadataWithFiles(synStore_obj, "./files/synapse_storage_manifest.csv", folder_synID)
       print(manifest_id)
       manifest_path <- paste0("synapse.org/#!Synapse:", manifest_id)
 

--- a/ingresspipe/synapse/store.py
+++ b/ingresspipe/synapse/store.py
@@ -420,8 +420,6 @@ class SynapseStorage(object):
                 if anno_k in metadataSyn:
                     annos[anno_k] = metadataSyn[anno_k]
 
-            print(annos)
-
             self.syn.set_annotations(annos)
             # self.syn.set_annotations(metadataSyn) -- deprecated code
 
@@ -445,22 +443,3 @@ class SynapseStorage(object):
         manifestSynapseFileId = self.syn.store(manifestSynapseFile).id
 
         return manifestSynapseFileId
-
-# if __name__ == "__main__":
-#     # create an instance of synapseclient.Synapse() and login
-#     syn = synapseclient.Synapse()
-
-#     try:
-#         syn.login("sujaypatil", "Sujay123@#@")
-#     except synapseclient.core.exceptions.SynapseNoCredentialsError:
-#         print("Please make sure the 'username' and 'password' keys in config have been filled out.")
-#     except synapseclient.core.exceptions.SynapseAuthenticationError:
-#         print("Please make sure the credentials in the config file are correct.")
-
-#     syn_store = SynapseStorage(syn=syn)
-
-#     # testing the association of entities with annotation(s) from manifest
-#     # synapse ID of "HTAN_CenterA_FamilyHistory" dataset and associating with it a validated manifest
-#     print("Testing association of entities with annotation from manifest...")
-#     manifest_syn_id = syn_store.associateMetadataWithFiles("./data/manifests/synapse_storage_manifest.csv", "syn21984120")
-#     print(manifest_syn_id)

--- a/ingresspipe/utils/google_api_utils.py
+++ b/ingresspipe/utils/google_api_utils.py
@@ -11,7 +11,6 @@ SYN_PWD = storage["Synapse"]["password"]
 
 def download_creds_file():
     if not os.path.exists("./credentials.json"):
-    
         print("Retrieving Google API credentials from Synapse...")
         syn = synapseclient.Synapse()
         syn.login(SYN_UNAME, SYN_PWD, rememberMe=False)

--- a/synLoginFun.py
+++ b/synLoginFun.py
@@ -1,12 +1,7 @@
 import synapseclient
 
-from ingresspipe.config.config import storage
-
-USERNAME = storage["Synapse"]["username"]
-PASSWORD = storage["Synapse"]["password"]
-
 syn = synapseclient.Synapse()
-syn.login(USERNAME, PASSWORD, rememberMe=False)
+syn_login = syn.login
 syn_getUserProfile = syn.getUserProfile
 syn_tableQuery = syn.tableQuery
 syn_get = syn.get

--- a/synStore_Session.py
+++ b/synStore_Session.py
@@ -6,17 +6,9 @@ import time
 import synapseclient
 from synapseclient import File
 
-from ingresspipe.config.config import storage
-
 from ingresspipe.synapse.store import SynapseStorage
 
-USERNAME = storage["Synapse"]["username"]
-PASSWORD = storage["Synapse"]["password"]
-
-syn = synapseclient.Synapse()
-syn.login(USERNAME, PASSWORD, rememberMe=False)
-
-syn_store = SynapseStorage(syn=syn)
+syn_store = SynapseStorage
 
 ### "Testing retrieval of project list from Synapse
 # get_projects_list = syn_store.getStorageProjects
@@ -38,10 +30,10 @@ syn_store = SynapseStorage(syn=syn)
 #    (  ('syn20687304', 'HCA immune cells census'),
 #       ('syn21682582', 'Test'),
 #       ('syn21682585', 'synapse_storage_manifest.csv'))]
-get_all_manifests = syn_store.getAllManifests
+# get_all_manifests = syn_store.getAllManifests
 
 ### updating fileset in a manifest associated with a dataset
 #manifestId = syn_store.update_dataset_manifest_files(dataset_id)
 # returns '' if no manifest exists
 # depends on fileview so it may take a few min for new files to show
-get_update_manifestId = syn_store.updateDatasetManifestFiles
+# get_update_manifestId = syn_store.updateDatasetManifestFiles


### PR DESCRIPTION
This PR addresses the [bug/issue #252](https://github.com/Sage-Bionetworks/HTAN-data-pipeline/issues/252). We revert back to using the `synStore_obj` and feeding it to the synapse APIs/methods.