### PR TITLE
Update schematic branch-related README instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Development Environment Setup
 
 ### Data Curator App Setup (frontend)
-Follow the steps below to make sure the _Data Curator App_ (frontend) is fully setup to work with the [Data Ingress Pipeline](https://github.com/Sage-Bionetworks/schematic/tree/main) (backend):
+Follow the steps below to make sure the _Data Curator App_ (frontend) is fully setup to work with the [schematic](https://github.com/Sage-Bionetworks/schematic/tree/main) (backend):
 
 Navigate to the location where you want to setup the application (i.e., the _Shiny Server_). Clone the code on this github branch (_shiny-server-1.0.0.rc1_):
 
@@ -23,9 +23,9 @@ _Note_:
 
 -------
 
-### Data Ingress Pipeline Setup (backend)
+### Schematic Setup (backend)
 
-The next step is to install the latest release of the [Data Ingress Pipeline](https://github.com/Sage-Bionetworks/schematic/tree/main) (backend) as a folder `schematic` inside the `HTAN_data_curator` folder and tie it together with this frontend. 
+The next step is to install the latest release of the [schematic](https://github.com/Sage-Bionetworks/schematic/tree/main) (backend) as a folder `schematic` inside the `HTAN_data_curator` folder and tie it together with this frontend. 
 
 To do so carry out the following steps:
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 ## Development Environment Setup
 
 ### Data Curator App Setup (frontend)
-Follow the steps below to make sure the _Data Curator App_ (frontend) is fully setup to work with the [Data Ingress Pipeline](https://github.com/Sage-Bionetworks/HTAN-data-pipeline/tree/develop) (backend):
+Follow the steps below to make sure the _Data Curator App_ (frontend) is fully setup to work with the [Data Ingress Pipeline](https://github.com/Sage-Bionetworks/schematic/tree/main) (backend):
 
-Navigate to the location where you want to setup the application (i.e., the _Shiny Server_). Clone the code on this github branch (_shiny-server-packaged-backend_):
+Navigate to the location where you want to setup the application (i.e., the _Shiny Server_). Clone the code on this github branch (_shiny-server-1.0.0.rc1_):
 
     git clone --single-branch --branch shiny-server-1.0.0.rc1 https://github.com/Sage-Bionetworks/HTAN_data_curator.git
 
@@ -25,13 +25,13 @@ _Note_:
 
 ### Data Ingress Pipeline Setup (backend)
 
-The next step is to install the latest release of the [Data Ingress Pipeline](https://github.com/Sage-Bionetworks/HTAN-data-pipeline/tree/develop) (backend) as a folder `HTAN-data-pipeline` inside the `HTAN_data_curator` folder and tie it together with this frontend. 
+The next step is to install the latest release of the [Data Ingress Pipeline](https://github.com/Sage-Bionetworks/schematic/tree/main) (backend) as a folder `schematic` inside the `HTAN_data_curator` folder and tie it together with this frontend. 
 
 To do so carry out the following steps:
 
-1. Inside the `HTAN_data_curator` folder, clone the repo from this [location](https://github.com/Sage-Bionetworks/HTAN-data-pipeline/tree/develop), by running the following command:
+1. Inside the `HTAN_data_curator` folder, clone the repo from this [location](https://github.com/Sage-Bionetworks/schematic/tree/main), by running the following command:
 
-    `git clone --single-branch --branch  develop https://github.com/Sage-Bionetworks/schematic.git`
+    `git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git`
 
 This creates a folder named `schematic` inside the the `HTAN_data_curator folder`.
 
@@ -47,7 +47,7 @@ If you can find the `schematic` package in the list of packages installed it was
 
     `synapse get syn21088684`
 
-4. Obtain the `token.pickle` file in `schematic` which is also necessary for authentication. If you do not already have this file run the `metadata_usage` example as follows inside `HTAN-data-pipeline`:
+4. Obtain the `token.pickle` file in `schematic` which is also necessary for authentication. If you do not already have this file run the `metadata_usage` example as follows inside `schematic`:
 
     `python examples/metadata_model.py`
 
@@ -61,4 +61,4 @@ _Notes:_
 
 - You need to be authorized to download protected Synapse files such as credentials. Please contact milen.nikolov@sagebase.org for access to the HTAN credentials.
 
-- If you want to test the backend you can run other things inside `schematic`, but in order to run the `examples/synapse_store.py` example, you need to configure your Synapse credentials in the `.synapseConfig` file (which can be found in the `HTAN-data-pipeline` directory), as described [here](https://github.com/Sage-Bionetworks/HTAN-data-pipeline/tree/develop#configure-synapse-credentials).
+- If you want to test the backend you can run other things inside `schematic`, but in order to run the `examples/synapse_store.py` example, you need to configure your Synapse credentials in the `.synapseConfig` file (which can be found in the `schematic` directory), as described [here](https://github.com/Sage-Bionetworks/schematic/tree/main#configure-synapse-credentials).


### PR DESCRIPTION
Updated the README so that it instructs users to use the `main` branch rather than the `develop` branch of the `schematic` app repo.

`main` - will always be a stable branch, and will be compatible with Data Curator App (at all times).
`develop` - will be stable with respect to the `schematic` backend features alone and may or may not be compatible with the working of the Data Curator App (at a specific point in time), but will be eventually.